### PR TITLE
Add a `.list()` method to `Dotenv`

### DIFF
--- a/src/main/kotlin/io/github/cdimascio/dotenv/Dotenv.kt
+++ b/src/main/kotlin/io/github/cdimascio/dotenv/Dotenv.kt
@@ -41,6 +41,13 @@ abstract class Dotenv {//}: Iterable<Map.Entry<String, String>> {
 //    abstract override operator fun iterator(): Iterator<Map.Entry<String, String>>
 
     /**
+     * Returns a list of the environment variables defined in the loaded .env file
+     *
+     * @return a list of key=>value pairs
+     */
+    abstract fun list(): List<Pair<String, String>>
+
+    /**
      * Returns the value for the environment variable, or the default value if absent
      *
      * @param envName The environment variable name
@@ -119,4 +126,6 @@ private class DotenvImpl(envVars: List<Pair<String, String>>) : Dotenv() {
 //    override fun iterator() = Collections.unmodifiableMap(map).iterator()
 
     override fun get(envName: String): String? = System.getenv(envName) ?: map[envName]
+
+    override fun list() = map.entries.map { it.key to it.value }
 }

--- a/src/test/kotlin/tests/BasicTests.kt
+++ b/src/test/kotlin/tests/BasicTests.kt
@@ -89,6 +89,15 @@ class DotEnvTest {
 //        }
 //    }
 
+    @test
+    fun dotenvList() {
+        val dotenv = Dotenv.configure()
+            .ignoreIfMalformed()
+            .load()
+        val envVars = dotenv.list()
+        assertEquals(envVars.size, 3)
+    }
+
     @test(expected = DotEnvException::class)
     fun dotenvMissing() {
         Dotenv.configure()


### PR DESCRIPTION
Currently, I am writing a gradle plugin for .env files, and it would be nice to be able to iterate over the list of variables that were defined in the .env file