### PR TITLE
Upgrade to dotenv-java v3.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build with Maven
+
+on:
+  push:
+    branches: [ "master", '*' ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn clean package dokka:javadocJar jacoco:report
+
+      - name: Report Coveralls
+        uses: coverallsapp/github-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build with Maven
 
 on:
   push:
-    branches: [ "master", '*' ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: java
-jdk:
-  - openjdk11
-
-script: mvn clean test
-
-sudo: false
-after_success:
-  - mvn clean dokka:javadocJar test jacoco:report coveralls:report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@
 #### 2. Build the project
 
 ```shell
-# java 11 required
-`export JAVA_HOME=/path/to/java11/home`
+# java 8 required
+`export JAVA_HOME=/path/to/java8/home`
 
 mvn clean compile test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@
 #### 2. Build the project
 
 ```shell
-# java 8 required
-`export JAVA_HOME=/path/to/java8/home`
+# java 11 required
+`export JAVA_HOME=/path/to/java11/home`
 
 mvn clean compile test
 ```
@@ -45,7 +45,7 @@ Contributors are not responsible for pushing packages to mavencentral and jcente
 mvn clean package dokka:javadocJar
 ```
 
-### Publish to Github Packages
+### Publish to GitHub Packages
 
 Add `distributionManagement` to `pom.xml`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Looking for the pure Java variant (no Kotlin), get [dotenv-java](https://github.
 <dependency>
     <groupId>io.github.cdimascio</groupId>
     <artifactId>dotenv-kotlin</artifactId>
-    <version>7.0.0</version>
+    <version>6.4.1</version>
 </dependency>
 ```
 
@@ -41,12 +41,12 @@ Looking for the pure Java variant (no Kotlin), get [dotenv-java](https://github.
 ### Gradle
 #### Gradle Groovy DSL
 ```groovy
-implementation 'io.github.cdimascio:dotenv-kotlin:7.0.0'
+implementation 'io.github.cdimascio:dotenv-kotlin:6.4.1'
 ```
 
 #### Gradle Kotlin DSL
 ```kotlin
-implementation("io.github.cdimascio:dotenv-kotlin:7.0.0")
+implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Looking for the pure Java variant (no Kotlin), get [dotenv-java](https://github.
 <dependency>
     <groupId>io.github.cdimascio</groupId>
     <artifactId>dotenv-kotlin</artifactId>
-    <version>6.4.1</version>
+    <version>7.0.0</version>
 </dependency>
 ```
 
@@ -41,12 +41,12 @@ Looking for the pure Java variant (no Kotlin), get [dotenv-java](https://github.
 ### Gradle
 #### Gradle Groovy DSL
 ```groovy
-implementation 'io.github.cdimascio:dotenv-kotlin:6.4.1'
+implementation 'io.github.cdimascio:dotenv-kotlin:7.0.0'
 ```
 
 #### Gradle Kotlin DSL
 ```kotlin
-implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
+implementation("io.github.cdimascio:dotenv-kotlin:7.0.0")
 ```
 
 ## Usage
@@ -66,7 +66,7 @@ With **Java**
 import io.github.cdimascio.dotenv.Dotenv;
 
 Dotenv dotenv = Dotenv.load();
-dotenv.get("MY_ENV_VAR1")
+dotenv.get("MY_ENV_VAR1");
 ```
 
 or with **Kotlin** 
@@ -217,7 +217,7 @@ for (e in dotenv.entries()) {
 	Dotenv
 	  .configure()
 	  .filename("myenv")
-	  .load()
+	  .load();
 	```
 	**Kotlin Dsl example**
 	
@@ -237,7 +237,7 @@ for (e in dotenv.entries()) {
 	Dotenv
 	  .configure()
 	  .ignoreIfMalformed()
-	  .load()
+	  .load();
 	```
 	**Kotlin Dsl example**
 	
@@ -257,7 +257,7 @@ for (e in dotenv.entries()) {
 	Dotenv
 	  .configure()
 	  .ignoreIfMissing()
-	  .load()
+	  .load();
 	```
 	**Kotlin Dsl example**
 	
@@ -277,7 +277,7 @@ for (e in dotenv.entries()) {
 	Dotenv
 	  .configure()
 	  .systemProperties()
-	  .load()
+	  .load();
 	```
 	**Kotlin Dsl example**
 	

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <main.class>io.cdimascio.DotenvKt</main.class>
     <junit.version>5.10.1</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.plugin>3.12.1</maven.compiler.plugin>
     <maven.source.plugin>3.3.0</maven.source.plugin>
     <maven.javadoc.plugin>3.6.3</maven.javadoc.plugin>
     <maven.jar.plugin>3.3.0</maven.jar.plugin>
@@ -106,6 +107,13 @@
   <build>
     <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven.compiler.plugin}</version>
+      </plugin>
+
       <plugin>
         <artifactId>kotlin-maven-plugin</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.cdimascio</groupId>
   <artifactId>dotenv-kotlin</artifactId>
-  <version>7.0.0</version>
+  <version>6.4.1</version>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.cdimascio</groupId>
   <artifactId>dotenv-kotlin</artifactId>
-  <version>6.4.1</version>
+  <version>7.0.0</version>
 
   <licenses>
     <license>
@@ -48,35 +48,23 @@
     </developer>
   </developers>
 
-
   <properties>
-    <dotenv.version>2.3.2</dotenv.version>
-    <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <kotlin.version>1.6.0</kotlin.version>
+    <dotenv.version>3.0.0</dotenv.version>
+    <maven.compiler.release>11</maven.compiler.release>
+    <kotlin.version>1.9.22</kotlin.version>
     <main.class>io.cdimascio.DotenvKt</main.class>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>5.10.1</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.source.plugin>3.0.1</maven.source.plugin>
-    <maven.javadoc.plugin>3.0.0</maven.javadoc.plugin>
-    <maven.jar.plugin>2.6</maven.jar.plugin>
-    <maven.jacoco.plugin>0.8.4</maven.jacoco.plugin>
-    <maven.coveralls.plugin>4.3.0</maven.coveralls.plugin>
-    <maven.surefire.plugin>2.22.0</maven.surefire.plugin>
-    <dokka.version>1.4.0</dokka.version>
+    <maven.source.plugin>3.3.0</maven.source.plugin>
+    <maven.javadoc.plugin>3.6.3</maven.javadoc.plugin>
+    <maven.jar.plugin>3.3.0</maven.jar.plugin>
+    <maven.jacoco.plugin>0.8.11</maven.jacoco.plugin>
+    <maven.surefire.plugin>3.2.3</maven.surefire.plugin>
+    <dokka.version>1.9.10</dokka.version>
     <bintray.subject>cdimascio</bintray.subject>
     <bintray.repo>maven</bintray.repo>
     <bintray.package>dotenv-kotlin</bintray.package>
   </properties>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jcenter</id>
-      <name>JCenter</name>
-      <url>https://jcenter.bintray.com/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <dependencies>
     <dependency>
@@ -94,8 +82,15 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
@@ -119,6 +114,7 @@
         <executions>
           <execution>
             <id>compile</id>
+            <phase>process-sources</phase>
             <goals>
               <goal>compile</goal>
             </goals>
@@ -156,13 +152,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven.surefire.plugin}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit4</artifactId>
-            <version>2.22.0</version>
-          </dependency>
-        </dependencies>
         <configuration>
           <includes>
             <include>**/*.java</include>
@@ -247,24 +236,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <version>${maven.coveralls.plugin}</version>
-        <configuration>
-          <repoToken>DTE7449Zg7tuwgrV6HeE0et1YB6JPPfeY</repoToken>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.2.3</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
@@ -305,7 +279,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -84,14 +84,7 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.1</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/tests/JavaTests.java
+++ b/src/test/java/tests/JavaTests.java
@@ -3,39 +3,32 @@ package tests;
 import io.github.cdimascio.dotenv.Dotenv;
 import io.github.cdimascio.dotenv.DotenvEntry;
 import io.github.cdimascio.dotenv.DotenvException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JavaTests {
-    private Map<String, String> envVars;
+    private final Map<String, String> envVars = Map.of(
+        "MY_TEST_EV1", "my test ev 1",
+        "MY_TEST_EV2", "my test ev 2",
+        "WITHOUT_VALUE", ""
+    );
 
-    @Before
-    public void setUp() {
-        envVars = new HashMap<>();
-        envVars.put("MY_TEST_EV1", "my test ev 1");
-        envVars.put("MY_TEST_EV2", "my test ev 2");
-        envVars.put("WITHOUT_VALUE", "");
-    }
-
-    @Test(expected = DotenvException.class)
+    @Test
     public void throwIfMalconfigured() {
-        Dotenv.configure().load();
+        assertThrows(DotenvException.class, () -> Dotenv.configure().load());
     }
 
-    @Test(expected = DotenvException.class)
+    @Test
     public void load() {
-        Dotenv dotenv = Dotenv.load();
-
-        for (String envName : envVars.keySet()) {
-            assertEquals(envVars.get(envName), dotenv.get(envName));
-        }
+        assertThrows(DotenvException.class, () -> {
+            Dotenv dotenv = Dotenv.load();
+            envVars.keySet().forEach(envName -> assertEquals(envVars.get(envName), dotenv.get(envName)));
+        });
     }
 
     @Test
@@ -44,13 +37,7 @@ public class JavaTests {
             .ignoreIfMalformed()
             .load();
 
-        dotenv
-            .entries()
-            .forEach(e -> assertEquals(dotenv.get(e.getKey()), e.getValue()));
-
-        for (DotenvEntry e : dotenv.entries()) {
-            assertEquals(dotenv.get(e.getKey()), e.getValue());
-        }
+        dotenv.entries().forEach(e -> assertEquals(dotenv.get(e.getKey()), e.getValue()));
     }
 
     @Test
@@ -63,32 +50,31 @@ public class JavaTests {
         Set<DotenvEntry> entriesAll = dotenv.entries();
         assertTrue(entriesInFile.size() < entriesAll.size());
 
-        for (Map.Entry<String, String> e: envVars.entrySet()) {
-            assertEquals(dotenv.get(e.getKey()), e.getValue());
-        }
+        envVars.forEach((key, value) -> assertEquals(dotenv.get(key), value));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void failToRemoveFromDotenv() {
         Dotenv dotenv = Dotenv.configure()
             .ignoreIfMalformed()
             .load();
 
-        Iterator<DotenvEntry> iter = dotenv.entries().iterator();
-        while (iter.hasNext()) {
-            iter.next();
-            iter.remove();
-        }
+        assertThrows(UnsupportedOperationException.class, () -> {
+            Iterator<DotenvEntry> iter = dotenv.entries().iterator();
+            while (iter.hasNext()) {
+                iter.next();
+                iter.remove();
+            }
+        });
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void failToAddToDotenv() {
-
         Dotenv dotenv = Dotenv.configure()
             .ignoreIfMalformed()
             .load();
 
-        dotenv.entries().add(new DotenvEntry("new", "value"));
+        assertThrows(UnsupportedOperationException.class, () -> dotenv.entries().add(new DotenvEntry("new", "value")));
     }
 
     @Test

--- a/src/test/kotlin/tests/BasicTests.kt
+++ b/src/test/kotlin/tests/BasicTests.kt
@@ -1,11 +1,12 @@
 package tests
 
-import io.github.cdimascio.dotenv.DotenvException
 import io.github.cdimascio.dotenv.Dotenv
+import io.github.cdimascio.dotenv.DotenvException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import org.junit.Test as test
+import org.junit.jupiter.api.Test as test
 
 class DotEnvTest {
     private val envVars = mapOf(
@@ -15,11 +16,13 @@ class DotEnvTest {
         "MULTI_LINE" to "hello\\nworld"
     )
 
-    @test(expected = DotenvException::class)
+    @test
     fun dotenvMalformed() {
-        Dotenv.configure()
-            .directory("./src/test/resources")
-            .load()
+        assertFailsWith<DotenvException> {
+            Dotenv.configure()
+                .directory("./src/test/resources")
+                .load()
+        }
     }
 
     @test
@@ -113,11 +116,13 @@ class DotEnvTest {
         }
     }
 
-    @test(expected = DotenvException::class)
+    @test
     fun dotenvMissing() {
-        Dotenv.configure()
-            .directory("/missing/.env")
-            .load()
+        assertFailsWith<DotenvException> {
+            Dotenv.configure()
+                .directory("/missing/.env")
+                .load()
+        }
     }
 
     @test
@@ -133,7 +138,7 @@ class DotEnvTest {
     }
 
     private fun assertHostEnvVar(env: Dotenv) {
-        val isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0
+        val isWindows = System.getProperty("os.name").lowercase().indexOf("win") >= 0
         if (isWindows) {
             val path = env["PATH"]
             assertNotNull(path)

--- a/src/test/kotlin/tests/DslTests.kt
+++ b/src/test/kotlin/tests/DslTests.kt
@@ -145,6 +145,32 @@ class DotEnvDslTest {
         assertNull(env["MY_TEST_EV1"])
     }
 
+    @test
+    fun systemProperties() {
+        val env = dotenv {
+            ignoreIfMalformed = true
+            systemProperties = true
+        }
+
+        assertHostEnvVar(env)
+        assertEquals("my test ev 1", env["MY_TEST_EV1"])
+        assertEquals("my test ev 1", System.getProperty("MY_TEST_EV1"))
+        env.entries().forEach {
+            System.clearProperty(it.key)
+        }
+    }
+
+    @test
+    fun noSystemProperties() {
+        val env = dotenv {
+            ignoreIfMalformed = true
+        }
+
+        assertHostEnvVar(env)
+        assertEquals("my test ev 1", env["MY_TEST_EV1"])
+        assertNull(System.getProperty("MY_TEST_EV1"))
+    }
+
     private fun assertHostEnvVar(env: Dotenv) {
         val isWindows = System.getProperty("os.name").lowercase().indexOf("win") >= 0
         if (isWindows) {

--- a/src/test/kotlin/tests/DslTests.kt
+++ b/src/test/kotlin/tests/DslTests.kt
@@ -147,7 +147,7 @@ class DotEnvDslTest {
     }
 
     private fun assertHostEnvVar(env: Dotenv) {
-        val isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0
+        val isWindows = System.getProperty("os.name").lowercase().indexOf("win") >= 0
         if (isWindows) {
             val path = env["PATH"]
             assertNotNull(path)

--- a/src/test/kotlin/tests/DslTests.kt
+++ b/src/test/kotlin/tests/DslTests.kt
@@ -1,15 +1,10 @@
 package tests
 
-import io.github.cdimascio.dotenv.DotenvException
 import io.github.cdimascio.dotenv.Dotenv
-import io.github.cdimascio.dotenv.DotenvEntry
+import io.github.cdimascio.dotenv.DotenvException
 import io.github.cdimascio.dotenv.dotenv
-import kotlin.test.assertTrue
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import org.junit.Test as test
+import kotlin.test.*
+import org.junit.jupiter.api.Test as test
 
 class DotEnvDslTest {
     private val envVars = mapOf(
@@ -24,9 +19,11 @@ class DotEnvDslTest {
         "HOME" to "dotenv_test_home"
     )
 
-    @test(expected = DotenvException::class)
+    @test
     fun dotenvMalformed() {
-        dotenv()
+        assertFailsWith<DotenvException> {
+            dotenv()
+        }
     }
 
     @test
@@ -94,7 +91,7 @@ class DotEnvDslTest {
         assertNotEquals(envVarsOverridenByHostEnv["HOME"], env["HOME"])
     }
 
-    @org.junit.Test
+    @test
     fun iteratorOverDotenvWithFilter() {
         val dotenv = Dotenv.configure()
             .ignoreIfMalformed()
@@ -128,10 +125,12 @@ class DotEnvDslTest {
         assertHostEnvVar(env)
     }
 
-    @test(expected = DotenvException::class)
+    @test
     fun dotenvMissing() {
-        dotenv {
-            directory = "/missing/.env"
+        assertFailsWith<DotenvException> {
+            dotenv {
+                directory = "/missing/.env"
+            }
         }
     }
 


### PR DESCRIPTION
## Contributions
- Update Java to 11
- Update to Junit5
- Bump dependency versions
- Switch to GitHub Actions for build
- Add missing dsl tests for `systemProperties`
- Test refactors along with deprecation removals
- Configure `Coveralls` with their currently supported GitHub Action integration instead of the maven-plugin